### PR TITLE
Fix missing dependency in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
     "version": "1.0",
     "dependencies": [
         "fmt",
-        "libusb"
+        "libusb",
+	"boost-crc"
     ]
 }


### PR DESCRIPTION
`vcpkg.json` was missing the dependency to `boost::crc`.