### PR TITLE
CLI11 Tool for MiniOmni

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ FetchContent_Populate(
   GIT_TAG v2.3.2
 )
 
-
 list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake")
 list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
 
@@ -60,5 +59,8 @@ target_link_libraries(MiniOmni PRIVATE CLI11::CLI11)
 #target_include_directories(MiniOmni PRIVATE ${CLI11_SOURCE_DIR}/include)
 #find_package(CLI11 CONFIG REQUIRED)
 #target_link_libraries(MiniOmni PUBLIC CLI11::CLI11)
+
+find_package(nlohmann_json CONFIG REQUIRED)
+target_link_libraries(MiniOmni PRIVATE nlohmann_json::nlohmann_json)
 
 target_compile_features(MiniOmni PUBLIC cxx_std_23)

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -11,15 +11,16 @@ int main(int argc, char **argv) {
     app.add_flag("-s,--search", search, "Prints all connected devices");
 
     std::vector<std::string> startUUID;
-
     app.add_option("-d,--device, --dev", startUUID, "Start the devices with the given UUIDs");
 
     std::string filePath;
-
     app.add_option("-o,--output", filePath, "Add a file you want the data to be saved in");
 
+    bool isJson = false; 
+    app.add_flag("-j,--json", isJson, "Add if you want the file to be in a JSON format"); 
 
     CLI11_PARSE(app, argc, argv);
+
 
     if(search) { // search for devices and print the UUID
         searchDevices();
@@ -29,11 +30,8 @@ int main(int argc, char **argv) {
     while(running) {
         if(!startUUID.empty()) { // Start the measurment with a set UUID and FilePath, data will be written in the filepath or in the console
             std::thread exitThread(waitForExit);
-            startMeasurementAndWrite(startUUID, filePath);
+            startMeasurementAndWrite(startUUID, filePath, isJson);
             exitThread.join(); // exit the programm with enter
         }
     }
-
-    std::cout << "End of the program" << std::endl;
-
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,8 @@
         "pkgconf",
         "fmt",
         "libusb",
-    "boost-crc"
+    "boost-crc", 
+    "nlohmann-json"
     ]
 }
 


### PR DESCRIPTION
Added a CLI Tool and calibrated values. 

The CLI Tool has the following options: 

  -h,--help                   Prints a help message and exit
  -s,--search                Prints all connected devices with their color 
  -d,--device,--dev     Starts the devices with the given UUIDs 
                                  Prints the values in the console 
  -o,--output              Saves the data from the given UUID in the given directory
  -j,--json                   Currently not available