### PR TITLE
Fix: CI Build with new exe name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,11 +47,11 @@ jobs:
         run: cmake --build build --parallel
 
       - name: Strip binary (optional)
-        run: strip build/MiniOmni || true
+        run: strip build/OmnAIScopeBackend || true
 
       # --- upload build artifact------------------
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MiniOmni-linux-${{ github.ref_name }}
-          path: build/MiniOmni
+          name: OmnAIScopeBackend-linux-${{ github.ref_name }}
+          path: build/OmnAIScopeBackend


### PR DESCRIPTION
The new name of the project broke the CI. Changing the name to the correct build name in the build.yaml should fix this problem 