### PR TITLE
fix(API): Receive UUID from API

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -835,7 +835,7 @@ nlohmann::json getDevicesAsJson(bool allInfo) {
     for (const auto& dev : devices)
     {
         const auto& id      = dev->getId().value();
-        const std::string& uuid = id.serial;
+        const std::string uuid = dev->getId()->serial;
         const auto [r,g,b]  = uuidToColor(uuid);
 
         response["devices"].push_back({ { "UUID", uuid } });


### PR DESCRIPTION
Fix UUID string in API answer of /UUID endpoint

Problem: 
When requesting an answer from the API /UUID endpoint only an empty string instead of the UUIDs of connected scopes was send to the client. See #39 . 

Fix: 
Sending the correct UUID instead of a reference to the UUID as this is deleted before the send process. ( one liner, my bad ) 

Current Behavior: 
The UUIDs from all connected Scopes should be received by the client via the /UUID endpoint request

Testing: 

Start the programm with .\OmnAIScopeBackend.exe -w -p 8080 on windows or ./OmnAIScopeBackend.exe -w -p 8080 on linux. 

Connect an OmnAIScope to your PC . 
Curl the /UUID endpoint: ```curl http://127.0.0.1:8808/UUID```

You should now receive something like this: 

{"colors":[{"color":{"b":59,"g":207,"r":147}}],"devices":[{"UUID":"E66368254F2FAB26"}]}
