### PR TITLE
Fix: Device search

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -233,25 +233,21 @@ public:
     void start()
     {
         auto self = shared_from_this();
+        searchDevices(); // Init Scopes
+        selectDevices(self->uuids); // select only chosen devices
 
         if (self->dataDestination == DataDestination::WS)
         {
             while (sendDataviaWSThreadActive)
             {
-                searchDevices(); // Init Scopes
-
-                selectDevices(self->uuids); // select only chosen devices
-                printOrWriteData(self);     // print the data in the console or save it in the given filepath
+                printOrWriteData(self);     // process data from devices 
             }
         }
         else
         {
             while (running)
             {
-                searchDevices(); // Init Scopes
-
-                selectDevices(self->uuids); // select only chosen devices
-                printOrWriteData(self);     // print the data in the console or save it in the given filepath
+                printOrWriteData(self);     // process data from devices 
             }
             resetDevices();
         }


### PR DESCRIPTION
## Summary

In this PR the logic for a regular search for devices in the programm is fixed. 

1.  Deletion of time buffer 

In the initial programm after each search the programm was stopped for 2 seconds. This is an old artifact from a time the devices were called in a while loop and would have been called to often if this stop did not exist. With the new architecture this is no longer needed and makes the programm slower as the devices are only called once each measurement. 

2. Search Devices only once 

In the initial programm devices are searched again after the printOrWriteData function finished. This leads to data loss as devices are initialized again while a measurement is running. To prevent this the searchDevices function as well as the selectDevices function now only run once on measurement start. 
