### PR TITLE
fix(bug): Add writer stop on ws disconnect

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -9,6 +9,9 @@ int main(int argc, char **argv) {
 
     running = true;
 
+    ControlWriter controlWriter{}; 
+
+
 // Create Optional CLI Tool
     CLI::App app{"OmnAI CLI"};
 
@@ -68,7 +71,7 @@ int main(int argc, char **argv) {
     }
 
     if(WS && running) {
-        websocket = std::thread(StartWS, std::ref(port));
+        websocket = std::thread(StartWS, std::ref(port), std::ref(controlWriter));
     }
 
     DataDestination destination = DataDestination::WS;
@@ -80,7 +83,7 @@ int main(int argc, char **argv) {
                 format = FormatType::JSON;
             }
             auto measurement = std::make_shared<Measurement>(startUUID, filePath, 10000, format, destination);
-            measurement->start();
+            measurement->start(controlWriter);
         }
     }
 


### PR DESCRIPTION
## Summary 

This PR adds logic to delete **Writer object** within runtime. 

Initially the writer object is only destroyed on programm exit. With the possibility of a websocket disconnecting and connecting again the writer would hold old data on reconnection and the WS would process this data. To prevent this on WS disconnection the Writer gets destroyed. 

## Implementation 
As the writer is started in its own thread it does not get destroyed at the end of a scope. Therefore a control class is needed to have a reference on this Writer. 
Add writer stop function in disconnect websocket function. 
Add ControlWriter class which controls the writer object.