### PR TITLE
Feature: Add stop measurement logic for Websocket BREAKING CHANGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,24 @@ Request the available UUIDs by accessing the REST API endpoint:
    wscat -c ws://<ip>:<port>/ws
    ```
 1. Start the measurement
-To start the measurement the client has to send the UUIDs to the websocket via 
+To start the measurement the client has to send the start command to the websocket:
    ```
-   <UUID1> <UUID2> ... <optional:Sample Rate> <optional:format>
+   {"type":"start", "uuids":["<UUID>", "<UUID>",...], "rate":<int>,"format":"<format>"}
    ```
-At the end of the command the client can send a sample rate which sets the sample rate for all chosen devices. The default sample rate is 60 Sa/s, the maximal sample rate is 100000 Sa/s. At the end of the command you can also set a format, available formats are "json, csv, binary". The default format is json. 
+
+The client can set the : 
+- UUID: datastreams measured via the device UUIDs
+- RATE: sampling rate of measurement 
+- FORMAT: format of the measurement 
+> The default sample rate is 60 Sa/s, the maximal sample rate is 100000 Sa/s. At the end of the command you can also set a format, available formats are "json, csv, binary". The default > format is json. 
 
 You should receive data in the chosen format from the chosen devices now. 
+
+2.Stop the measurement 
+To stop the measurement send the stop command to the websocket : 
+```
+{"type":"stop"}
+```
 
 ## How to build the project
 **Important: If you don't have access to the private communication submodule it is currently not possible to build this project locally. A CI Build is integrated for Linux that can be used in a fork** 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
                 format = FormatType::JSON;
             }
             auto measurement = std::make_shared<Measurement>(startUUID, filePath, 10000, format, destination);
-            measurement->start(controlWriter);
+            measurement->startLocal(controlWriter);
         }
     }
 


### PR DESCRIPTION
## Summary 

Add logic to stop a measurement via a client command. A measurement can now be requested via the client from the server, stopped and a new measurement can be requested without closing the websocket. 

BREAKING CHANGES: Change client command format 

## Details 

Initially the websocket was build to receive one command and then continuously provide data. 
This does not fit the standards for the client anymore as more features are needed: Saving data, stopping a measurement, change sampling rate while a measurement is taken. 
For this the websocket has to be structured way differently. 
Instead of starting everything directly in the onmessage thread the commands for the WS are set via a FIFO pattern in a queue. 
A CommandWorker processes this commands and starts the correct process in the application. 

To make this more thread save than the initial statemanagement, threads started by the CommandWorker are jthreads. Instead of a lot of booleans and thread handling all threads can be stopped by a stop request. 

## Testing 

To test the new websocket first start the application with -w -p <port> .

Send a command to the websocket via a client (tested with wscat) : 

To start : {"type":"start","uuids"["<uuid>",...],"rate":<int>,"format":"<csv,json,binary>"}

If measurement already runs: No new measurement is started 
If measurement not started: You should now receive data in the format and with the sample rate requested 

To stop: {"type":"stop"} 
You should stop receiving data 

Running start again should send you data from a new measurement. 

Try this in different variations --> This should not break. 