### PR TITLE
fix(race): Fix race condition in stop function

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -1211,7 +1211,6 @@ void startMeasurement(Command& cmd, ControlWriter& ctrl, WSContext& wsCtx){
 */
 void stopMeasurement(ControlWriter& ctrl, WSContext& wsCtx){
     websocketConnectionActive = false;
-    resetDevices();
     if (wsCtx.sendThread.joinable()) {        
         wsCtx.sendThread.request_stop();      
         wsCtx.sendThread.join();             
@@ -1221,6 +1220,7 @@ void stopMeasurement(ControlWriter& ctrl, WSContext& wsCtx){
         wsCtx.msmntThread.join();             
     }
     ctrl.stopWriter(); 
+    resetDevices(); // do not switch order 
     startWriter = true;
     wsCtx.currentMeasurement = nullptr; 
 }
@@ -1401,7 +1401,8 @@ void StartWS(int &port, ControlWriter &controlWriter)
                             cmd.conn->send_text(R"({"type":"error","msg":"not running"})");
                             break;
                         }
-                        else stopMeasurement(controlWriter, wsCtx); 
+                        else stopMeasurement(controlWriter, wsCtx);
+                        break;  
                     }
                 }
             }


### PR DESCRIPTION
## Bug

After adding "break" to the stop case statement , stopping a measurement leads to a programm crash without error message. Suggestion : The new stop function triggers a race condition only visible due to new break statement. 

## Problem 
If devices are reset before the sendThread is stopped the sampler used in the FormatterQueue is deleted when still used.
Switch order of deletion fixed error.

## Implementation 
Switch resetDevices and sendThread join. Add break to stop case statement.

