### PR TITLE
feat(save): Add save option to WS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ To stop the measurement send the stop command to the websocket :
 {"type":"stop"}
 ```
 
+3.Save the measurement 
+AFTER stopping the measurement send the save command to the websocket, it is important to send the same uuids as used for the measurement: 
+```
+ {"type":"save", "uuids":["<UUID>", "<UUID>",...], "path":"<filepath>","format":"<format>"}
+`` 
+
+path: filename in which the file is saved 
+format: format in which the file is saved 
+
+Download the file from the API endpoint : /download/<filename>
+
 ## How to build the project
 **Important: If you don't have access to the private communication submodule it is currently not possible to build this project locally. A CI Build is integrated for Linux that can be used in a fork** 
 


### PR DESCRIPTION
## Summary 

Add option to save data after a measurement in a file.  
Add API endpoint to download file after saving : download/<filename> 

## Testing 

It is expected that data can only be saved after the measurement stopped. 

Userflow: 
- connect to WS
- start Measurement via command 
- stop measurement via command
- Save measurement via command 

--> The WS sends a message after the file was successfully saved 

- send get request to API endpoint 

--> You should now receive the file 



Note: This is a trivial implementation not using a ring buffer system for faster developing with the current architecture of the backend. Savings cant be made while a measurement is running. If the RAM is
full no trigger is set that will stop the measurement. The architecture is chosen to implement the functionality for OmnAIView for the time before NaDI is finished.
It is expected to be a work around for a few weeks. If this feature should be further improved this should be refactored.