### PR TITLE
feat(WS): Add type to JSON message

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To stop the measurement send the stop command to the websocket :
 AFTER stopping the measurement send the save command to the websocket, it is important to send the same uuids as used for the measurement: 
 ```
  {"type":"save", "uuids":["<UUID>", "<UUID>",...], "path":"<filepath>","format":"<format>"}
-`` 
+```
 
 path: filename in which the file is saved 
 format: format in which the file is saved 

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -1310,7 +1310,7 @@ void processDeque(std::stop_token stopToken, crow::websocket::connection &conn, 
                 nlohmann::ordered_json message;
                 message.update(wsPackagesQueue.front());
                 wsPackagesQueue.pop();
-                message["type"].push_back("data"); 
+                message["type"] = "data"; 
                 if (!measurement->uuids.empty())
                 {
                     message["devices"] = nlohmann::json::array();


### PR DESCRIPTION
## Summary 
This PR enhances the WS data format by types for send messages. 
Add type "data" to JSON message of WS.

## Reason 
With new possible answers from the WS the messages send should have a "type" to be easier parsable.

Note: Currently not implemented for CSV and Binary Message

BREAKING CHANGES: New syntax for received WS format