### PR TITLE
fix(calib): Timeout for calibration

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -956,6 +956,7 @@ void searchDevices()
         devices.clear();
         deviceManager.clearDevices();
         initDevices();
+        std::this_thread::sleep_for(std::chrono::seconds(1)); // timeout for calibration
     }
 }
 /**


### PR DESCRIPTION
After calibration data to the scope the device needs a few ms to actually receive this data. If a measurement is started beforehand data is not calibrated.

Add a timeout after initDevices