### PR TITLE
Add SaveDeque Class, optimize TransformData, fix unbounded memory growth

### DIFF
--- a/.~lock.Data#
+++ b/.~lock.Data#
@@ -1,0 +1,1 @@
+,pascal,HermannThinkPad,08.08.2025 14:47,file:///home/pascal/.config/libreoffice/4;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -39,6 +39,9 @@ int main(int argc, char **argv) {
     bool printVersion = false;
     app.add_flag("--version", printVersion, "Prints the current version. Version is set via a git tag.");
 
+    int bufferSizeMB = -1;
+    app.add_option("-b, --buffer-size", bufferSizeMB, "Set save-buffer size in MiB (10–1000)");
+
     if (argc <= 1) {// if no parameters are given
         std::cout << app.help() << std::endl;
         return 0;
@@ -50,6 +53,20 @@ int main(int argc, char **argv) {
         std::cerr << app.help() << std::endl;
         return app.exit(e);
     }
+
+    if (bufferSizeMB != -1) {
+    	if (bufferSizeMB < 10 || bufferSizeMB > 1000) {
+        	std::cerr << "Error: Buffer size must be between 10 and 1000 MiB\n";
+           	return 1;
+        }
+        size_t newBytes = static_cast<size_t>(bufferSizeMB) * 1024 * 1024;
+        bool ok = saveDataQueue.resizeMaxBytes(newBytes);
+        std::cout << "Save-buffer resize returned: "
+                 << (ok ? "OK" : "FAILED")
+                 << ", new capacity = " << saveDataQueue.maxBytes()/(1024*1024)
+                 << " MiB\n";
+    }
+
 
     if(printVersion) {
         std::cout << "Version " << PROJECT_VERSION << std::endl;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -1,5 +1,8 @@
 #include "data.hpp"
 
+// Buffer size is currently set according to feeling and can still be adjusted
+inline constexpr std::size_t BufferMinMiB = 10;
+inline constexpr std::size_t BufferMaxMiB = 1000;
 
 int main(int argc, char **argv) {
 
@@ -55,7 +58,7 @@ int main(int argc, char **argv) {
     }
 
     if (bufferSizeMB != -1) {
-    	if (bufferSizeMB < 10 || bufferSizeMB > 1000) {
+    	if (bufferSizeMB < BufferMinMiB || bufferSizeMB > BufferMaxMiB) {
         	std::cerr << "Error: Buffer size must be between 10 and 1000 MiB\n";
            	return 1;
         }


### PR DESCRIPTION
# Summary 

This PR introduces a new SaveDeque class for storing measurement data with a fixed capacity, optimizes TransformData, and fixes a bug that caused unbounded RAM growth. The writer has been updated to use the new deque.

# Implementation

- Add new Class "SaveDeque"
    - Create a Fixed-size deque for measurement data.
    - Stores data up to the specified limit.
    - Deletes oldest data to make room for new data.

- Add Option to set deque size via CLI

    
# Bug Fix

- Fix an issue that led to unbounded memory growth
    - Replace the unbounded Queue with SaveDeque

# Update

- Optimize TransformData
    -  Produce Sample in a single loop instead of two

- Update Writer to use SaveDeque

- Update SAVE Option
    - Write data from SaveDeque to the specified file


    



