### PR TITLE
Add Record

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -894,7 +894,6 @@ class ControlWriter {
         void printOrWriteData(std::shared_ptr<Measurement> measurement, std::optional<std::stop_token> stopToken = std::nullopt);
         void stopWriter();   
         void saveData(WSContext& wsCtx);
-	void startOneShotSave(std::shared_ptr<Measurement> m);
 
 	void startRecording(const std::shared_ptr<Measurement>& m);
     	void stopRecording(crow::websocket::connection* conn);
@@ -1736,7 +1735,6 @@ void StartWS(int &port, ControlWriter &controlWriter)
     ([](const std::string& fname) {
  	if (fname.find("..") != std::string::npos) return crow::response(400);
         std::ifstream f(fname, std::ios::binary);
-        //if (fname.find_first_of("\\/") != std::string::npos) return crow::response(400);
         if (!f) return crow::response(404);
 
         std::string body{ std::istreambuf_iterator<char>(f),


### PR DESCRIPTION
# Summary

This PR introduces a recording function that allows the server to write running measurement data to a file in parallel with the WebSocket stream. The recording reads exclusively from the SaveDeque and does not affect the live stream.

# Sequence diagram

![Sequence Diagram](https://raw.githubusercontent.com/PascalH87/OmnAIScope-DataServer/diagram/sequence-diagram.png)




# Usage

Start: <pre>{"type":"record","set":"start","format":"csv|json"}</pre> Format-Default = csv

Stop: <pre>{"type":"record","set":"stop"}</pre>

Server responses:

<pre>{"type":"record","status":"started"} or {"type":"record","status":"already-running"}</pre>

<pre>{"type":"record","status":"stopping"} or {"type":"record","status":"not-running"}</pre>

On start, the server ensures a Record/ directory exists and creates a temp file named with a timestamp (e.g. YYMMDD_HHMM.tmp). On stop, the file is atomically renamed to the final extension (.csv/.json).

# Implementation

- Helpfunctions to build <timestamp>.tmp and ro rename to the final extension

-  New recording pipeline in ControlWriter

-  Dedicated recorder_ Writer instance with recordingMode flag

- Lifecycle guarded by atomic RECORDING

- File/dir management via std::filesystem (portable across Linux/Windows)

# Behavior

- Live WS data continues without interruption

- Recording does not modify wsCtx.currentMeasurement

- .tmp Renaming only after a clean stop

# Test

1. Start WS measurement; verify live data flows.
2. Send record start (csv and json): a .tmp file appears and grows in Record/.
3. Send record stop: .tmp renames to the correct final extension.
4. Trigger a save during/after recording; both paths work independently.