### PR TITLE
Enhance file management and add REST endpoints for listing and deleting measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ The OmnAIScope-DataServer can be executed via the command line on Windows, Linux
 
 The CLI-Tool includes the commands: 
 
--h, --help Displays a help message with detailed usage instructions in the console.
--s, --search Lists the UUIDs of all connected devices, displaying their current LED color for easy identification.
--d, --device, --dev Initiates a measurement session for specified devices by their UUIDs. Multiple devices can be specified, and their data will be displayed directly in the console. 
--o, --output Writes the data from the selected devices to the specified file path. By default, the data is saved in .csv format.
--j, --json Changes the output file format to JSON. 
--w, --websocket Opens a Websocket, as well as a REST API. 
--p, --port Set a port for the Websocket to start on. 
--v, --verbose Prints out additional information about the software's process.
+-h, --help Displays a help message with detailed usage instructions in the console.<br>
+-s, --search Lists the UUIDs of all connected devices, displaying their current LED color for easy identification.<br>
+-d, --device, --dev Initiates a measurement session for specified devices by their UUIDs. Multiple devices can be specified, and their data will be displayed directly in the console.<br> 
+-o, --output Writes the data from the selected devices to the specified file path. By default, the data is saved in .csv format.<br>
+-j, --json Changes the output file format to JSON.<br> 
+-w, --websocket Opens a Websocket, as well as a REST API.<br> 
+-p, --port Set a port for the Websocket to start on.<br> 
+-v, --verbose Prints out additional information about the software's process.<br>
+-b, --buffer-size Set save-buffer size in MiB (10-1000)<br>
 --version Prints out the current SW version 
 
 #### How to use the Websocket: 
@@ -29,7 +30,7 @@ The CLI-Tool includes the commands:
 1. Start the Websocket 
 Start the executable via 
    ```
-   .\OmnAIScopeBackend -w -p <port>
+   .\OmnAIScope-DataServer -w -p <port>
    ```
 1. Retrieve UUIDS via REST API 
 Request the available UUIDs by accessing the REST API endpoint:
@@ -80,7 +81,7 @@ To stop recording, the record command must be sent via websocket while recording
 {"type":"record","set":"stop"}
 ```
 
-Download the file from the API endpoint : /download/Record/(filename)
+Download the file from the API endpoint : /download/Record/&lt;filename&gt;
 
 4.Save the measurement
 #### Documentation of saved files format can be found in docs\FileFormats 
@@ -92,7 +93,7 @@ AFTER stopping the measurement send the save command to the websocket, it is imp
 path: filename in which the file is saved 
 format: format in which the file is saved 
 
-Download the file from the API endpoint : /download/(filename)
+Download the file from the API endpoint : /download/Save/&lt;filename&gt;
 
 ## How to build the project
 **Important: If you don't have access to the private communication submodule it is currently not possible to build this project locally. A CI Build is integrated for Linux that can be used in a fork** 
@@ -183,7 +184,7 @@ If you know how to configure paths and toolchain files manually, `vcpkg` can als
 
 ### 7. Generate the Build System with CMake
 
-1. Return to the root project directory (e.g., `OmnAIScopeBackend`):
+1. Return to the root project directory (e.g., `OmnAIScope-DataServer`):
    ```cmd
    cd ..
    ```
@@ -201,7 +202,7 @@ If you know how to configure paths and toolchain files manually, `vcpkg` can als
    ```cmd
    cmake --build build --config Release
    ```
-   This will compile the source code and generate the `OmnAIScopeBackend.exe` file in the `build/Release` directory.
+   This will compile the source code and generate the `OmnAIScope-DataServer.exe` file in the `build/Release` directory.
 
 ---
 
@@ -213,7 +214,7 @@ If you know how to configure paths and toolchain files manually, `vcpkg` can als
    ```
 1. Run the program:
    ```cmd
-   .\OmnAIScopeBackend.exe
+   .\OmnAIScope-DataServer.exe
    ```
 
 The program should start, and you can interact with it as instructed.
@@ -262,7 +263,7 @@ We set this for reproducibility reasons—everything then comes from the system 
 
 Clone the OmnAIScope-DataServer project from the repository:
 ```sh
-git clone git@github.com:omnai-project/OmnAIScope-DevDataServer.git --recurse-submodules
+git clone git@github.com:omnai-project/OmnAIScope-DataServer.git --recurse-submodules
 cd OmnAIScope-DataServer
 cmake -B ./build/
 cmake --build ./build/
@@ -271,7 +272,7 @@ cmake --build ./build/
 You can start the data-server with 
 
 ```sh
-   .build/OmnAIScopeBackend
+   .build/OmnAIScope-DataServer
 ``` 
 
 The executable can be copied standalone without further packaging. 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -102,7 +102,8 @@ int main(int argc, char **argv) {
             if(isJson) {
                 format = FormatType::JSON;
             }
-            auto measurement = std::make_shared<Measurement>(startUUID, filePath, 10000, format, destination);
+	    std::string out = ensureSavePath(filePath, format);
+            auto measurement = std::make_shared<Measurement>(startUUID, out, 10000, format, destination);
             measurement->startLocal(controlWriter);
         }
     }

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -45,6 +45,9 @@ int main(int argc, char **argv) {
     int bufferSizeMB = -1;
     app.add_option("-b, --buffer-size", bufferSizeMB, "Set save-buffer size in MiB (10–1000)");
 
+    std::string delTokenCli;
+    app.add_option("-t, --delete-token", delTokenCli, "Set DELETE_TOKEN at startup");
+
     if (argc <= 1) {// if no parameters are given
         std::cout << app.help() << std::endl;
         return 0;
@@ -55,6 +58,18 @@ int main(int argc, char **argv) {
         // if input is incorrect
         std::cerr << app.help() << std::endl;
         return app.exit(e);
+    }
+
+    const char* already = get_env_delete_token();
+
+    if (!delTokenCli.empty()) {
+        set_env_delete_token(delTokenCli, true);
+    } else if (!already) {
+        set_env_delete_token("OmnAI", false);
+    }
+
+    if (const char* tok = get_env_delete_token()) {
+        std::cout << "[INFO] DELETE_TOKEN = " << tok << std::endl;
     }
 
     if (bufferSizeMB != -1) {

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -102,7 +102,14 @@ int main(int argc, char **argv) {
             if(isJson) {
                 format = FormatType::JSON;
             }
-	    std::string out = ensureSavePath(filePath, format);
+
+	    std::string out = filePath;
+    	    if (!out.empty() && !isBlank(out)) {
+        	out = ensureSavePath(out, format);
+    	    } else {
+        	out.clear();
+    	    }
+
             auto measurement = std::make_shared<Measurement>(startUUID, out, 10000, format, destination);
             measurement->startLocal(controlWriter);
         }

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -45,8 +45,6 @@ int main(int argc, char **argv) {
     int bufferSizeMB = -1;
     app.add_option("-b, --buffer-size", bufferSizeMB, "Set save-buffer size in MiB (10–1000)");
 
-    std::string delTokenCli;
-    app.add_option("-t, --delete-token", delTokenCli, "Set DELETE_TOKEN at startup");
 
     if (argc <= 1) {// if no parameters are given
         std::cout << app.help() << std::endl;
@@ -58,18 +56,6 @@ int main(int argc, char **argv) {
         // if input is incorrect
         std::cerr << app.help() << std::endl;
         return app.exit(e);
-    }
-
-    const char* already = get_env_delete_token();
-
-    if (!delTokenCli.empty()) {
-        set_env_delete_token(delTokenCli, true);
-    } else if (!already) {
-        set_env_delete_token("OmnAI", false);
-    }
-
-    if (const char* tok = get_env_delete_token()) {
-        std::cout << "[INFO] DELETE_TOKEN = " << tok << std::endl;
     }
 
     if (bufferSizeMB != -1) {

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -445,35 +445,6 @@ namespace {
         return (e == ".csv" || e == ".json" || e == ".dat");
     }
 
-    inline bool has_delete_permission(const crow::request& req, const std::string&) {
-    	const std::string auth = req.get_header_value("Authorization");
-    	if (auth.empty()) return false;
-
-    	const char* env = std::getenv("DELETE_TOKEN");
-    	const std::string expected = std::string("Bearer ") + (env ? std::string(env) : "OmnAI");
-
-    	if (auth.size() != expected.size()) return false;
-
-    	volatile unsigned char diff = 0;
-    	for (size_t i = 0; i < auth.size(); ++i) diff |= (unsigned char)(auth[i] ^ expected[i]);
-    	return diff == 0;
-    }
-
-    inline bool set_env_delete_token(const std::string& token, bool overwrite = true) {
-	#if defined(_WIN32)
-    		if (!overwrite) {
-        		if (const char* cur = std::getenv("DELETE_TOKEN")) return true;
-    		}
-    		return _putenv_s("DELETE_TOKEN", token.c_str()) == 0;
-	#else
-    		return ::setenv("DELETE_TOKEN", token.c_str(), overwrite ? 1 : 0) == 0;
-	#endif
-    }
-
-    inline const char* get_env_delete_token() {
-    	return std::getenv("DELETE_TOKEN");
-    }
-
     inline crow::response json_error(int code, std::string msg) {
         crow::response r{code, nlohmann::json({{"status","error"},{"error",std::move(msg)}}).dump()};
         r.set_header("Content-Type", "application/json");
@@ -1934,7 +1905,7 @@ void StartWS(int &port, ControlWriter &controlWriter)
     cors
     .global()
     .origin("*")
-    .headers("Origin", "Content-Type", "Accept", "X-Custom-Header", "Authorization")
+    .headers("Origin", "Content-Type", "Accept", "X-Custom-Header")
     .methods("POST"_method, "GET"_method, "OPTIONS"_method)
     .max_age(600);
 
@@ -2025,11 +1996,6 @@ void StartWS(int &port, ControlWriter &controlWriter)
            	// Folder Whitelist
         	if (!in_allowed_folder(folder)) {
            		return json_error(400, "folder must be 'Save' or 'Record'");
-        	}
-
-        	// Permission Check
-        	if (!has_delete_permission(req, folder)) {
-            		return json_error(403, "forbidden");
         	}
 
         	// File name whitelist (no paths / no hidden files / fixed length)


### PR DESCRIPTION
# Summary 

This PR improves the management of measurement files by introducing a dedicated “Save” folder and providing new REST endpoints for listing and deleting measurements. File naming now corresponds to the data flow, and responses are returned in a uniform JSON format.

# Usage 

### Saving via WebSocket

- Default filename & extension
```
{"type":"save"}  
``` 
Save/YYMMDD_HHMM.csv (or .json if format:"json", .dat as fallback)

- Custom

```
{"type":"save", "path":"Data", "format":"json"}  
``` 
Save/Data.json

The client receives:
```
{"type":"file-ready","url":"/download/Save/<filename>.<csv/json>"}

``` 
### Saving via CLI

- -o, --output
    - No or blank path > Save/YYMMDD_HHMM.csv (or .json if -j, --json)
    - Filename > Save/&lt;filename&gt;.csv (or .json if -j, --json)
    
### Download

- Only from Save/ or Record/
```
curl http://<ip>:<port>/download/Save/<filename>.<ext>
curl http://<ip>:<port>/download/Record/<filename>.<ext>
```
### List measurements

```
curl http://<ip>:<port>/show_measurements
```
Returns:
``` 
[
    {
        "Record": [
            {
                "Created": "<date>",
                "File": "<filename>.<ext>",
                "Size": "<filesize>"
            }
        ]
    },
    {
        "Save": [
            {
                "Created": "<date>",
                "File": "<filename>.<ext>",
                "Size": "<filesize>"
            }
        ]
    }
]
``` 
### Delete measurement

Only deletes a single regular file within Save/ or Record/
```
curl -X DELETE http://<ip>:<port>/delete_measurements/Save/<filename>.<ext>
curl -X DELETE http://<ip>:<port>/delete_measurements/Record/<filename>.<ext>
```
# Implementation

### Path normalization and naming

- ensureSavePath() creates directories and generates timestamp filenames with enforced extension when no path is provided
- Applied in both WebSocket save flow and CLI output handling

### Download security

- /download/<path> rejects traversal and enforces root folder checks.

### show_measurements

- Lists both directories Save/ and Record/, with helper functions for size and creation time

### delete_measurements

- Only allows DELETE for files in Save/ or Record/
- Returns structured JSON for both success and error conditions

# Test

#### 1. Saving (WebSocket)
```
{"type":"save","format":"csv"}
```

- File appears in Save/ with timestamp name
- Custom path with/without extension enforces correct naming

#### 2.  Saving (CLI)

- With -o, --output Data.csv → Save/Data.csv

#### 3. Download

- Valid requests to Save/ or Record/ = Status Code 200
- Traversal or other directories = Status Code 400 / 403

#### 4. show_measurements

- Returns JSON with correct size and human readable timestamps

#### 5. delete_measurements

- Valid file =  deleted, JSON ok
- Non-existent file = JSON 404 with message
- Invalid filename/folder = JSON 400 error

# Diagram

<img width="1341" height="1471" alt="show_delete_seq" src="https://github.com/user-attachments/assets/df9e73b9-403b-41b5-9ef7-7c304e4211a1" />
